### PR TITLE
Added `fiducial` and `latex_name` methods

### DIFF
--- a/fitk/tensors.py
+++ b/fitk/tensors.py
@@ -691,7 +691,7 @@ class FisherMatrix:
 
         Examples
         --------
-        Set a Fisher matrix:
+        Create a Fisher matrix:
         >>> fm = FisherMatrix(np.diag([1, 2]),
         ... names=['a', 'b'], fiducials=[2, 3])
 
@@ -704,6 +704,36 @@ class FisherMatrix:
 
         return self.fiducials[np.where(self.names == name)][0]
 
+    def set_fiducial(self, name: str, value: float):
+        """
+        Sets the fiducial of parameter `name`.
+
+        Raises
+        ------
+        ParameterNotFoundError
+            if the name is not in the Fisher object
+
+        Examples
+        --------
+        Create a Fisher matrix:
+        >>> fm = FisherMatrix(np.diag([1, 2]),
+        ... names=['a', 'b'], fiducials=[2, 3])
+
+        Set the value of the fiducial associated to parameter `b`:
+        >>> fm.set_fiducial('b', 4)
+        >>> fm
+        FisherMatrix(
+            array([[1., 0.],
+               [0., 2.]]),
+            names=array(['a', 'b'], dtype=object),
+            latex_names=array(['a', 'b'], dtype=object),
+            fiducials=array([2., 4.]))
+        """
+        if name not in self.names:
+            raise ParameterNotFoundError(name, self.names)
+
+        self.fiducials[np.where(self.names == name)[0]] = value
+
     def latex_name(self, name: str) -> str:
         r"""
         Returns the LaTeX name associated to the parameter `name`.
@@ -715,7 +745,7 @@ class FisherMatrix:
 
         Examples
         --------
-        Set a Fisher matrix:
+        Create a Fisher matrix:
         >>> fm = FisherMatrix(np.diag([1, 2]),
         ... names=['a', 'b'], latex_names=[r'$\mathbf{A}$', r'$\mathbf{B}$'])
 
@@ -727,6 +757,36 @@ class FisherMatrix:
             raise ParameterNotFoundError(name, self.names)
 
         return self.latex_names[np.where(self.names == name)][0]
+
+    def set_latex_name(self, name: str, value: str):
+        r"""
+        Sets the LaTeX name of parameter `name`.
+
+        Raises
+        ------
+        ParameterNotFoundError
+            if the name is not in the Fisher object
+
+        Examples
+        --------
+        Create a Fisher matrix:
+        >>> fm = FisherMatrix(np.diag([1, 2]),
+        ... names=['a', 'b'], fiducials=[2, 3])
+
+        Set the value of the fiducial associated to parameter `b`:
+        >>> fm.set_latex_name('b', r'$\mathcal{B}$')
+        >>> fm
+        FisherMatrix(
+            array([[1., 0.],
+               [0., 2.]]),
+            names=array(['a', 'b'], dtype=object),
+            latex_names=array(['a', '$\\mathcal{B}$'], dtype=object),
+            fiducials=array([2., 3.]))
+        """
+        if name not in self.names:
+            raise ParameterNotFoundError(name, self.names)
+
+        self.latex_names[np.where(self.names == name)[0]] = value
 
     def is_valid(self):
         """

--- a/tests/test_tensors.py
+++ b/tests/test_tensors.py
@@ -741,6 +741,13 @@ class TestFisherMatrix:
         with pytest.raises(ParameterNotFoundError):
             fm.fiducial("asdf")
 
+        with pytest.raises(ParameterNotFoundError):
+            fm.set_fiducial("q", 10)
+
+        fm.set_fiducial("a", 6)
+
+        assert np.allclose(fm.fiducials, [6, 3])
+
     def test_latex_name(self):
         """
         Test for the `latex_name` method
@@ -755,3 +762,10 @@ class TestFisherMatrix:
 
         with pytest.raises(ParameterNotFoundError):
             fm.latex_name("asdf")
+
+        with pytest.raises(ParameterNotFoundError):
+            fm.set_latex_name("asdf", "y")
+
+        fm.set_latex_name("b", "q")
+
+        assert np.all(fm.latex_names == np.array([r"$\mathbf{A}$", "q"]))


### PR DESCRIPTION
The methods return the fiducial and LaTeX name corresponding to the parameter `name`.
Fixes #32.