### PR TITLE
Fixed pytest warning in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           # This assumes pytest is installed via the install-package step above
           command: |
             # we don't need any other dependencies
-            python3 -m pip install matplotlib scipy numpy pytest git+https://github.com/jcgoran/cosmicfish@feature/pip-install
+            python3 -m pip install matplotlib scipy numpy pytest pytest-mpl git+https://github.com/jcgoran/cosmicfish@feature/pip-install
             python3 -m pytest -k 'not test_interfaces'
 
 # Invoke jobs via workflows


### PR DESCRIPTION
Apparently, running the tests without installing `pytest-mpl` raises a `PytestReturnNotNoneWarning`, which can, according to the docs, be suppressed by actually installing that module.