### PR TITLE
Added class for parameter specification

### DIFF
--- a/fitk/__init__.py
+++ b/fitk/__init__.py
@@ -61,6 +61,17 @@ There are several options you can use:
 ... latex_names=['$x$', '$y$', '$z$']
 ... )
 
+There is also the option of specifying the names as instances of
+`fitk.utilities.P` using the `fitk.tensors.FisherMatrix.from_parameters`
+constructor:
+>>> # same as above
+>>> my_matrix = FisherMatrix.from_parameters(
+... np.diag([1, 2, 3]),
+... P('a', -1, '$x$'),
+... P('b', 0, '$y$'),
+... P('c', 1, '$z$')
+... )
+
 ## ...sort a matrix according to some criterion?
 
 Use the `fitk.tensors.FisherMatrix.sort` method, which returns a new Fisher

--- a/fitk/__init__.py
+++ b/fitk/__init__.py
@@ -29,10 +29,11 @@ Throughout the documentation, it is assumed that the modules are imported
 in the following way:
 
 >>> import numpy as np
->>> from fitk import FisherMatrix, FisherFigure1D, FisherFigure2D, FisherBarFigure, D, FisherDerivative
+>>> from fitk import P, FisherMatrix, FisherFigure1D, FisherFigure2D, FisherBarFigure, D, FisherDerivative
 
 The most important classes are:
 
+- `fitk.utilities.P`: for specifying Fisher parameters
 - `fitk.tensors.FisherMatrix`: for manipulating Fisher matrices
 - `fitk.graphics.FisherBarFigure`, `fitk.graphics.FisherFigure1D`, and
   `fitk.graphics.FisherFigure2D`: for plotting Fisher matrices
@@ -230,7 +231,7 @@ be as simple as:
 
 The Fisher matrix with some parameter `a` can then be obtained using the
 `fitk.derivatives.FisherDerivative.fisher_matrix` method:
->>> my_matrix = interface.fisher_matrix(D('a', fiducial=0, abs_step=1e-3))
+>>> my_matrix = interface.fisher_matrix(D(P('a', fiducial=0), abs_step=1e-3))
 
 The method takes an optional `parameter_dependence` argument, which specifies
 whether the signal or the covariance are parameter-dependent (or both), the
@@ -246,7 +247,7 @@ be as simple as:
 >>> interface = MyInterface()
 
 and the derivatives can be obtained with:
->>> derivative = interface.derivative('signal', D('a', fiducial=0, abs_step=1e-3))
+>>> derivative = interface.derivative('signal', D(P('a', fiducial=0), abs_step=1e-3))
 
 The first argument can either be the string `signal` or `covariance`, while the
 rest are a list of derivatives you wish to compute.
@@ -364,4 +365,4 @@ from fitk.derivatives import D, FisherDerivative
 from fitk.graphics import FisherBarFigure, FisherFigure1D, FisherFigure2D
 from fitk.operations import bayes_factor, kl_divergence, kl_matrix
 from fitk.tensors import FisherMatrix
-from fitk.utilities import math_mode
+from fitk.utilities import P, math_mode

--- a/fitk/interfaces/coffe_interfaces.py
+++ b/fitk/interfaces/coffe_interfaces.py
@@ -23,8 +23,10 @@ except ImportError:
 else:
     IMPORT_SUCCESS = True
 
+
 # first party imports
 from fitk.derivatives import FisherDerivative
+from fitk.utilities import P
 
 
 def _parse_and_set_args(
@@ -78,13 +80,13 @@ class CoffeMultipolesDerivative(FisherDerivative):
     Compute the first derivative of the signal (multipoles of 2PCF), using a
     fourth-order central derivative scheme, w.r.t. $h$ with a fiducial value of
     $0.67$ and an absolute step size $10^{-3}$:
-    >>> cosmo.derivative('signal', D('h', 0.67, 1e-3))
+    >>> cosmo.derivative('signal', D(P('h', 0.67), 1e-3))
 
     Compute the Fisher matrix with $\Omega_\mathrm{m}$ and $n_s$ as the
     parameters:
     >>> fm = cosmo.fisher_matrix(
-    ... D(name='omega_m', fiducial=0.32, abs_step=1e-3),
-    ... D(name='n_s', fiducial=0.96, abs_step=1e-3))
+    ... D(P(name='omega_m', fiducial=0.32), abs_step=1e-3),
+    ... D(P(name='n_s', fiducial=0.96), abs_step=1e-3))
     """
 
     __software_name__ = "coffe"

--- a/fitk/interfaces/misc_interfaces.py
+++ b/fitk/interfaces/misc_interfaces.py
@@ -14,6 +14,7 @@ from scipy.integrate import quad
 
 # first party imports
 from fitk.derivatives import D, FisherDerivative
+from fitk.utilities import P
 
 
 def _hubble(config: dict):
@@ -65,18 +66,18 @@ class SupernovaDerivative(FisherDerivative):
     >>> sn = SupernovaDerivative()
 
     Compute the derivative of the signal w.r.t. $\Omega_\mathrm{m}$:
-    >>> sn.derivative('signal', D(name='omega_m', fiducial=0.32, abs_step=1e-3))
+    >>> sn.derivative('signal', D(P(name='omega_m', fiducial=0.32), abs_step=1e-3))
     array([-3.17838358])
 
     Compute the mixed derivative of the signal w.r.t. both $\Omega_\mathrm{m}$
     and $w$:
-    >>> sn.derivative('signal', D('omega_m', 0.32, 1e-3), D('w', -1, 1e-3))
+    >>> sn.derivative('signal', D(P('omega_m', 0.32), 1e-3), D(P('w', -1), 1e-3))
     array([2.94319875])
 
     Compute the Fisher with $\Omega_\mathrm{m}$ and $w$ as parameters:
     >>> fm1 = sn.fisher_matrix(
-    ... D('omega_m', 0.32, 1e-3, latex_name=r'$\Omega_\mathrm{m}$'),
-    ... D('w', -1, 1e-3, latex_name='$w$'))
+    ... D(P('omega_m', 0.32, latex_name=r'$\Omega_\mathrm{m}$'), 1e-3),
+    ... D(P('w', -1, latex_name='$w$'), 1e-3))
     >>> fm1
     FisherMatrix(
         array([[10.1021222 ,  3.13019854],
@@ -87,8 +88,8 @@ class SupernovaDerivative(FisherDerivative):
 
     Finally, check that we don't alter the result by using a smaller stepsize:
     >>> fm2 = sn.fisher_matrix(
-    ... D('omega_m', 0.32, 1e-4, latex_name=r'$\Omega_\mathrm{m}$'),
-    ... D('w', -1, 1e-4, latex_name='$w$'))
+    ... D(P('omega_m', 0.32, latex_name=r'$\Omega_\mathrm{m}$'), 1e-4),
+    ... D(P('w', -1, latex_name='$w$'), 1e-4))
     >>> fm2 == fm1
     True
     """

--- a/fitk/tensors.py
+++ b/fitk/tensors.py
@@ -24,6 +24,7 @@ from fitk.utilities import (
     FisherEncoder,
     MismatchingSizeError,
     MismatchingValuesError,
+    P,
     ParameterNotFoundError,
     get_index_of_other_array,
     is_iterable,
@@ -312,7 +313,6 @@ class FisherMatrix:
 
         self._size = np.shape(self._values)[0]
         self._ndim = np.ndim(self._values)
-
         # setting the fiducials
         if fiducials is None:
             self._fiducials = np.zeros(self._size, dtype=float)

--- a/fitk/tensors.py
+++ b/fitk/tensors.py
@@ -347,6 +347,18 @@ class FisherMatrix:
                 self._latex_names,
             )
 
+    @classmethod
+    def from_parameters(cls, values, *args: P):
+        r"""
+        Alternative constructor, which takes as arguments instances of `P`
+        """
+        return cls(
+            values,
+            names=[arg.name for arg in args],
+            fiducials=[arg.fiducial for arg in args],  # type: ignore
+            latex_names=[arg.latex_name for arg in args],  # type: ignore
+        )
+
     @property
     def matrix(self):
         """

--- a/fitk/utilities.py
+++ b/fitk/utilities.py
@@ -9,11 +9,41 @@ from __future__ import annotations
 import json
 import math
 from collections.abc import Collection, Sequence
+from dataclasses import dataclass
 from math import factorial
 from typing import Optional, Union
 
 # third party imports
 import numpy as np
+
+
+@dataclass
+class P:
+    r"""
+    Class for describing a generic parameter
+
+    Parameters
+    ----------
+    name : str
+        the name of the parameter
+
+    fiducial : float, optional
+        the fiducial value of the parameter. If not specified, defaults to 0
+
+    latex_name : str, optional
+        the LaTeX (display) name of the parameter. If not specified, defaults
+        to the same value as `name`
+    """
+
+    name: str
+    fiducial: Optional[float] = None
+    latex_name: Optional[str] = None
+
+    def __post_init__(self):
+        if self.fiducial is None:
+            self.fiducial = 0
+        if self.latex_name is None:
+            self.latex_name = self.name
 
 
 class FisherEncoder(json.JSONEncoder):

--- a/tests/test_tensors.py
+++ b/tests/test_tensors.py
@@ -26,6 +26,7 @@ from fitk.tensors import FisherMatrix, _process_fisher_mapping
 from fitk.utilities import (
     MismatchingSizeError,
     MismatchingValuesError,
+    P,
     ParameterNotFoundError,
     math_mode,
 )

--- a/tests/test_tensors.py
+++ b/tests/test_tensors.py
@@ -783,3 +783,21 @@ class TestFisherMatrix:
     def test_eigenvectors(self):
         fm = FisherMatrix(np.diag([1, 2, 3]))
         assert np.allclose(fm.eigenvectors(), np.linalg.eigh(fm.values)[-1])
+
+    def test_from_parameters(self):
+        fm = FisherMatrix.from_parameters(
+            np.diag([1, 2, 3]),
+            P("a"),
+            P("b", latex_name=r"$\mathrm{B}$", fiducial=-3),
+            P("c", fiducial=1),
+        )
+
+        assert all(fm.names == ["a", "b", "c"])
+        assert np.allclose(fm.fiducials, [0, -3, 1])
+        assert all(fm.latex_names == ["a", r"$\mathrm{B}$", "c"])
+
+        with pytest.raises(MismatchingSizeError):
+            fm = FisherMatrix.from_parameters(
+                np.diag([1, 2]),
+                P("a"),
+            )


### PR DESCRIPTION
The `D` class was in charge of too many things (namely, `latex_name` was completely unrelated to it), so this PR adds a class `P`, which is in charge of only 3 things:

- the parameter name
- the fiducial value of that parameter
-  the display (LaTeX) name of that parameter

It also adds a class method `from_parameters`, as an alternative constructor to `FisherMatrix`, with which one can use the following to create a Fisher matrix:

```python
FisherMatrix.from_parameters(
    P(<name1>, <fiducial1>, <latex_name1>),
    P(<name2>, <fiducial2>, <latex_name2>),
    ...
)
```

Note that it adds an incompatible change to `D` (since the members `name`, `latex_name`, and `fiducial` were replaced by `parameter`), so a version bump is in order.