### PR TITLE
Added third-party software as extras

### DIFF
--- a/fitk/__init__.py
+++ b/fitk/__init__.py
@@ -15,6 +15,45 @@ rel="noopener noreferrer">PyPI</a>, and can be installed via `pip`:
 pip install fitk
 ```
 
+In case you want to also install the various third-party software for which
+there are interfaces for computing derivatives with FITK, you can instead do:
+
+```sh
+pip install fitk[[INTERFACE]]
+```
+
+where `[INTERFACE]` is one of the [supported third-party
+software](fitk/interfaces.html). In case you want to try to install all of the
+supported third-party software at once, you can run:
+
+```sh
+pip install fitk[interfaces]
+```
+
+# Quickstart
+
+Load the core modules:
+>>> from fitk import FisherMatrix, FisherFigure2D, D, P
+
+Load one of the [supported interfaces](fitk/interfaces.html):
+>>> from fitk.interfaces.coffe_interfaces import CoffeMultipolesDerivative
+
+Set up an instance of the interface:
+>>> config = CoffeMultipolesDerivative()
+
+Compute some Fisher matrices:
+>>> fm = config.fisher_matrix(
+... D(P(name='omega_m', fiducial=0.3), abs_step=1e-3),
+... D(P(name='omega_baryon', fiducial=0.04), abs_step=1e-3),
+... )
+
+Note that the matrix can easily be saved for later:
+>>> fm.to_file('fisher_matrix_example.json', metadata={'comment': 'Example Fisher matrix'})
+
+Plot some contours of the resulting matrix:
+>>> ff = FisherFigure2D(show_1d_curves=True, show_joint_dist=True)
+>>> ff.plot(fm, label='COFFE forecast example')
+
 # Bug reports and feature requests
 
 Development of FITK is currently done <a

--- a/fitk/interfaces/__init__.py
+++ b/fitk/interfaces/__init__.py
@@ -1,8 +1,8 @@
 """
 Interfaces for FITK.
 
-This module defines interfaces to various third-party software with which
-one can compute Fisher matrices using finite differences.
+This module defines interfaces to various third-party software with which one
+can compute Fisher matrices.
 
 ### Important notice
 Due to the complexities involved in distributing software that is not under
@@ -10,6 +10,16 @@ direct control of the developers/maintainers of `fitk` (version, installation,
 license issues, etc.), any external, third-party software (such as cosmological
 codes) is *not* bundled with `fitk` (i.e. installed automatically), and must be
 installed separately by the user.
+
+### List of interfaces
+
+#### <a href="https://github.com/JCGoran/coffe" target="_blank" rel="noopener noreferrer">COFFE</a>
+
+- installable with `pip install fitk[coffe]` (only on Linux; for other
+  platforms, see <a
+  href="https://github.com/JCGoran/coffe#development-version-including-non-linux-machines"
+  target="_blank" rel="noopener noreferrer">here</a>)
+- for documentation of available interfaces, see `fitk.interfaces.coffe_interfaces`
 
 ### Computation of custom derivatives
 To define a new interface for computing derivatives, one should define a class

--- a/poetry.lock
+++ b/poetry.lock
@@ -251,6 +251,17 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
+name = "coffe"
+version = "3.0.dev6"
+description = "Python wrapper for the COrrelation Function Full-sky Estimator code"
+category = "main"
+optional = true
+python-versions = ">=3.7"
+
+[package.dependencies]
+numpy = ">=1.19.5"
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -1908,10 +1919,14 @@ python-versions = ">=3.7"
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
+[extras]
+coffe = ["coffe"]
+interfaces = ["coffe"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4"
-content-hash = "a246682b0cbb9628f5e5a9d064372a5997f411842501ca09a44ffc5089ee1bd9"
+content-hash = "ced5bd1ee3fbb4019aec828cd8592dfc36a4596ca33e2a830a604d4b0679a30c"
 
 [metadata.files]
 aiofiles = [
@@ -2183,6 +2198,14 @@ charset-normalizer = [
 click = [
     {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
     {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+]
+coffe = [
+    {file = "coffe-3.0.dev6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdf027958a58698453f4b098aaaeab75b60dba7699c7ddde8014559c1005f733"},
+    {file = "coffe-3.0.dev6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ef1bfe0d6263567eab322135ba1fe7b1975931fe14960f7df34feabf679a021"},
+    {file = "coffe-3.0.dev6-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c488c53a871e05cf7656e6a9c7a7d2a0cdc5c6814fd295c342168ebe9cfb6024"},
+    {file = "coffe-3.0.dev6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c528b7fe3766f4b9037f1e06c42dea9c1e207ffbb4479d0d956c9b37a46777b"},
+    {file = "coffe-3.0.dev6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46d74ab4974e929d6871c9427aa2f3cfe7061806ddeeb63a7037ba3355a980b9"},
+    {file = "coffe-3.0.dev6.tar.gz", hash = "sha256:17162ea20970cafd2d0afb8934f7ed31ceedbc67d8058cc0289369987bfe34ac"},
 ]
 colorama = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,11 @@ matplotlib = [
     {version = "^3.6", python = ">=3.11"}
 ]
 sympy = {version = "*"}
+coffe = { version = "*", optional = true }
+
+[tool.poetry.extras]
+coffe = ["coffe"]
+interfaces = ["coffe"]
 
 [tool.poetry.dev-dependencies]
 black = "*"


### PR DESCRIPTION
Closes #12, at least for software which provide a Python version in one form or another.
For now only [COFFE](https://github.com/JCGoran/coffe) is supported, but other software can be added easily.