### PR TITLE
Added `__str__` to `FisherDerivative`

### DIFF
--- a/fitk/derivatives.py
+++ b/fitk/derivatives.py
@@ -12,7 +12,7 @@ import warnings
 from collections.abc import Collection, Sequence
 from dataclasses import dataclass
 from itertools import product
-from typing import Optional
+from typing import Optional, Union
 
 # third party imports
 import numpy as np
@@ -291,19 +291,31 @@ class FisherDerivative:
     array that is shape-compatible with the output of the `signal` method.
     """
 
-    name: Optional[str] = None
-    """The name of the software which we are interfacing"""
+    software_names: Optional[Union[str, dict[str, str]]] = None
+    """
+    The name of the software which we are interfacing. Can be either a
+    string, or a dictionary with the keys `signal` and `covariance` and the
+    names of each software as values
+    """
     version: Optional[str] = None
-    """The version of the interface"""
+    """
+    The version of the interface (is *not* necessarily the same as the version
+    of the software itself)
+    """
     authors: Optional[list[dict[str, str]]] = None
-    """The list of authors of the interface"""
+    """
+    The list of authors of the interface (is *not* necessarily the same as the
+    authors of the software itself)
+    """
     urls: Optional[dict[str, str]] = None
-    """Any URL(s) to the original software"""
+    """
+    Any URL(s) to the original software(s)
+    """
 
     def __str__(self):
         return (
             f"{self.__class__.__name__}(\n"
-            f"\tsoftware name: {self.name},\n"
+            f"\tsoftware name(s): {self.software_names},\n"
             f"\tinterface version: {self.version},\n"
             f"\tauthors: {self.authors},\n"
             f"\tURL(s): {self.urls}\n"

--- a/fitk/derivatives.py
+++ b/fitk/derivatives.py
@@ -291,6 +291,25 @@ class FisherDerivative:
     array that is shape-compatible with the output of the `signal` method.
     """
 
+    name: Optional[str] = None
+    """The name of the software which we are interfacing"""
+    version: Optional[str] = None
+    """The version of the interface"""
+    authors: Optional[list[dict[str, str]]] = None
+    """The list of authors of the interface"""
+    urls: Optional[dict[str, str]] = None
+    """Any URL(s) to the original software"""
+
+    def __str__(self):
+        return (
+            f"{self.__class__.__name__}(\n"
+            f"\tsoftware name: {self.name},\n"
+            f"\tinterface version: {self.version},\n"
+            f"\tauthors: {self.authors},\n"
+            f"\tURL(s): {self.urls}\n"
+            ")"
+        )
+
     def __init__(self, *args, **kwargs):
         """
         Create an instance.

--- a/fitk/interfaces/coffe_interfaces.py
+++ b/fitk/interfaces/coffe_interfaces.py
@@ -88,9 +88,12 @@ class CoffeMultipolesDerivative(FisherDerivative):
     ... D(P(name='n_s', fiducial=0.96), abs_step=1e-3))
     """
 
-    name = "coffe"
-    urls = dict(github="https://github.com/JCGoran/coffe")
-    version = "3.0.0"
+    software_names = "coffe"
+    urls = dict(
+        github="https://github.com/JCGoran/coffe",
+        pypi="https://pypi.org/project/coffe/",
+    )
+    version = "1.0.0"
     authors = [
         dict(
             name="Goran Jelic-Cizmek",
@@ -116,7 +119,7 @@ class CoffeMultipolesDerivative(FisherDerivative):
         """
         if not self.__imported__:
             raise ImportError(
-                f"Unable to import the `{self.name}` module, "
+                f"Unable to import the `{self.software_names}` module, "
                 "please make sure it is installed; "
                 f"for additional help, please consult one of the following URL(s): {self.urls}"
             )

--- a/fitk/interfaces/coffe_interfaces.py
+++ b/fitk/interfaces/coffe_interfaces.py
@@ -88,10 +88,15 @@ class CoffeMultipolesDerivative(FisherDerivative):
     ... D(P(name='n_s', fiducial=0.96), abs_step=1e-3))
     """
 
-    __software_name__ = "coffe"
-    __url__ = "https://github.com/JCGoran/coffe"
-    __version__ = "3.0.0"
-    __maintainers__ = ["Goran Jelic-Cizmek <goran.jelic-cizmek@unige.ch>"]
+    name = "coffe"
+    urls = dict(github="https://github.com/JCGoran/coffe")
+    version = "3.0.0"
+    authors = [
+        dict(
+            name="Goran Jelic-Cizmek",
+            email="goran.jelic-cizmek@unige.ch>",
+        )
+    ]
     __imported__ = IMPORT_SUCCESS
 
     def __init__(
@@ -111,9 +116,9 @@ class CoffeMultipolesDerivative(FisherDerivative):
         """
         if not self.__imported__:
             raise ImportError(
-                f"Unable to import the `{self.__software_name__}` module, "
+                f"Unable to import the `{self.name}` module, "
                 "please make sure it is installed; "
-                f"for additional help, please consult the following URL: {self.__url__}"
+                f"for additional help, please consult one of the following URL(s): {self.urls}"
             )
 
         self._config = config if config is not None else {}
@@ -211,15 +216,6 @@ class CoffeMultipolesDerivative(FisherDerivative):
         )
 
         return result
-
-    @property
-    def __credits__(self):
-        return (
-            f"Software: {self.__software_name__}\n"
-            f"Version: {self.__version__}\n"
-            f"URL: {self.__url__}\n"
-            f"Interface maintainer(s): {self.__maintainers__}"
-        )
 
 
 class CoffeMultipolesTildeDerivative(CoffeMultipolesDerivative):

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -14,8 +14,24 @@ import pytest
 # first party imports
 from fitk.derivatives import D, FisherDerivative, matrix_element_from_input
 from fitk.interfaces.misc_interfaces import SupernovaDerivative
-from fitk.utilities import P
-from fitk.utilities import ValidationError, _expansion_coefficient
+from fitk.utilities import P, ValidationError, _expansion_coefficient
+
+
+def test_srt():
+    """
+    Check for str of `FisherDerivative`
+    """
+    fd = FisherDerivative()
+    assert str(fd) == "\n".join(
+        [
+            f"{fd.__class__.__name__}(",
+            f"\tsoftware name(s): {fd.software_names},",
+            f"\tinterface version: {fd.version},",
+            f"\tauthors: {fd.authors},",
+            f"\tURL(s): {fd.urls}",
+            ")",
+        ]
+    )
 
 
 def test_expansion_coefficient():


### PR DESCRIPTION
Closes #26. `__repr__` is still missing, but I think it should be implemented separately by the actual interfaces, since the constructors can vary from interface to interface.