### PR TITLE
Added option to use pseudoinverse of matrix

### DIFF
--- a/fitk/derivatives.py
+++ b/fitk/derivatives.py
@@ -513,6 +513,7 @@ class FisherDerivative:
         self,
         *args: D,
         parameter_dependence: str = "signal",
+        use_pinv: bool = False,
         external_covariance: Optional[Sequence[Sequence[float]]] = None,
         rounding_threshold: float = 0.0,
         kwargs_signal: Optional[dict] = None,
@@ -530,6 +531,11 @@ class FisherDerivative:
         parameter_dependence : {'signal', 'covariance', 'both'}
             where the parameter dependence is located, in the signal, the
             covariance, or both (default: 'signal')
+
+        use_pinv : bool, optional
+            use the Moore-Penrose pseudoinverse to obtain the inverse of the
+            covariance matrix (default: False). Can be useful if the covariance
+            matrix is weakly signular. Use with caution!
 
         external_covariance : array_like, optional
             the external covariance matrix to use when computing the result
@@ -636,7 +642,13 @@ class FisherDerivative:
                 *zip(names, fiducials), **kwargs_covariance
             )
 
-        inverse_covariance_matrix = np.linalg.inv(covariance_matrix)
+        if use_pinv:
+            inverse_covariance_matrix = np.linalg.pinv(
+                covariance_matrix,
+                hermitian=True,
+            )
+        else:
+            inverse_covariance_matrix = np.linalg.inv(covariance_matrix)
 
         covariance_shape = np.shape(inverse_covariance_matrix)
 

--- a/fitk/derivatives.py
+++ b/fitk/derivatives.py
@@ -576,6 +576,9 @@ class FisherDerivative:
         ValueError
             if the argument `external_covariance` is not a square matrix
 
+        LinAlgError
+            if the covariance matrix is singular
+
         Notes
         -----
         The `order` parameter is ignored if passed to `D`.

--- a/fitk/tensors.py
+++ b/fitk/tensors.py
@@ -1414,6 +1414,11 @@ class FisherMatrix:
             use the Moore-Penrose pseudoinverse (default: False). Can be useful
             if the Fisher matrix is weakly singular. Use with caution!
 
+        Raises
+        ------
+        LinAlgError
+            if the Fisher matrix is singular
+
         Returns
         -------
         array_like : float

--- a/fitk/tensors.py
+++ b/fitk/tensors.py
@@ -2285,6 +2285,7 @@ class FisherMatrix:
         self,
         name1: str,
         name2: str,
+        **kwargs,
     ) -> float:
         r"""
         Return the correlation coefficient between two parameters.
@@ -2297,11 +2298,17 @@ class FisherMatrix:
         name2 : str
             the name of the second parameter
 
+        **kwargs
+            any kwargs passed to `correlation_matrix`
+
         Returns
         -------
         float
         """
-        return self.__class__(self.correlation_matrix(), names=self.names)[name1, name2]
+        return self.__class__(
+            self.correlation_matrix(**kwargs),
+            names=self.names,
+        )[name1, name2]
 
     def figure_of_merit(self) -> float:
         r"""
@@ -2331,9 +2338,14 @@ class FisherMatrix:
         """
         return np.linalg.slogdet(self.values)[-1] / 2
 
-    def figure_of_correlation(self) -> float:
+    def figure_of_correlation(self, **kwargs) -> float:
         r"""
         Compute the figure of correlation (FoC).
+
+        Parameters
+        ----------
+        **kwargs
+            any kwargs passed to `correlation_matrix`
 
         Returns
         -------
@@ -2351,4 +2363,4 @@ class FisherMatrix:
         $$
         where $\mathsf{P}$ denotes the correlation matrix.
         """
-        return -np.linalg.slogdet(self.correlation_matrix())[-1] / 2
+        return -np.linalg.slogdet(self.correlation_matrix(**kwargs))[-1] / 2

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -467,6 +467,15 @@ class TestMiscDerivatives:
             kwargs_covariance={"sample_kwarg": "sample_value"},
         )
 
+        fm_with_pinv = sn.fisher_matrix(
+            D(P("omega_m", 0.32), 1e-3),
+            kwargs_signal={"sample_kwarg": "sample_value"},
+            kwargs_covariance={"sample_kwarg": "sample_value"},
+            use_pinv=True,
+        )
+
+        assert fm == fm_with_pinv
+
         with pytest.raises(KeyError):
             sn.config = dict(q="asdf")
 

--- a/tests/test_tensors.py
+++ b/tests/test_tensors.py
@@ -837,6 +837,16 @@ class TestFisherMatrix:
         assert np.allclose(m_cf_marginalized1.get_fisher_matrix(), m_marg1.values)
         assert np.allclose(m_cf_marginalized2.get_fisher_matrix(), m_marg2.values)
 
+    def test_inverse(self):
+        fm = FisherMatrix([[1, -1], [-1, 1]])
+
+        # singular matrix
+        with pytest.raises(np.linalg.LinAlgError):
+            fm.inverse()
+
+        # using the pseudoinverse, we do not encounter any errors
+        fm.inverse(use_pinv=True)
+
     def test_ufunc(self):
         """
         Test of numpy universal functions.


### PR DESCRIPTION
Added `use_pinv` kwarg (defaults to False) to various functions that use the matrix inverse, which toggles whether to use the [Moore-Penrose](https://en.wikipedia.org/wiki/Moore%E2%80%93Penrose_inverse) pesudoinverse instead of attempting to compute the regular inverse. This should be used with caution, as, while the Moore-Penrose pseudoinverse is unique, the results may not be completely reliable.